### PR TITLE
Allow test errors to be sent from the browser console

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Errors thrown directly from the browser console don't get caught by Sentry, so y
 document.dispatchEvent(new Event('sentry-test-error'))
 ```
 
-This functionality can be disabled in your .env:
+This functionality can be disabled in your `.env`:
 
 ```
 SENTRY_VUE_ALLOW_TEST_ERRORS=false

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Check out the [sentry/sentry-laravel readme](https://github.com/getsentry/sentry
 
 ## Testing
 
-Errors thrown directly from the browser console don't get caught by sentry, so you can test whether or not the frontend error reporting works by sending a test error in the browser console with:
+Errors thrown directly from the browser console don't get caught by Sentry, so you can test whether or not the frontend error reporting works by sending a test error in the browser console with:
 
 ```js
 document.dispatchEvent(new Event('sentry-test-error'))

--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ SENTRY_VUE_INTEGRATION_REPLAY=true
 
 Check out the [sentry/sentry-laravel readme](https://github.com/getsentry/sentry-laravel) for configuration of the laravel package.
 
+## Testing
+
+Errors thrown directly from the browser console don't get caught by sentry, so you can test whether or not the frontend error reporting works by sending a test error in the browser console with:
+
+```js
+document.dispatchEvent(new Event('sentry-test-error'))
+```
+
+This functionality can be disabled in your .env:
+
+```
+SENTRY_VUE_ALLOW_TEST_ERRORS=false
+```
+
 ## License
 
 GNU General Public License v3. Please see [License File](LICENSE) for more information.

--- a/config/rapidez/sentry-vue.php
+++ b/config/rapidez/sentry-vue.php
@@ -4,7 +4,7 @@ return [
     // Configuration as defined in the docs: https://docs.sentry.io/platforms/javascript/guides/vue/configuration/
     'configuration' => [
         'enabled' => env('SENTRY_VUE_ENABLED', true),
-        'allow_test_errors' => env('SENTRY_ALLOW_TEST_ERRORS', true),
+        'allow_test_errors' => env('SENTRY_VUE_ALLOW_TEST_ERRORS', true),
 
         // Amount of errors to be logged to sentry (1.00 = 100%)
         'sampleRate' => env('SENTRY_VUE_SAMPLE_RATE', 100) / 100,

--- a/config/rapidez/sentry-vue.php
+++ b/config/rapidez/sentry-vue.php
@@ -4,10 +4,12 @@ return [
     // Configuration as defined in the docs: https://docs.sentry.io/platforms/javascript/guides/vue/configuration/
     'configuration' => [
         'enabled' => env('SENTRY_VUE_ENABLED', true),
+        'allow_test_errors' => env('SENTRY_ALLOW_TEST_ERRORS', true),
 
         // Amount of errors to be logged to sentry (1.00 = 100%)
         'sampleRate' => env('SENTRY_VUE_SAMPLE_RATE', 100) / 100,
     ],
+
 
     // For integrations, see: https://docs.sentry.io/platforms/javascript/guides/vue/configuration/integrations/
     // If you want to add extra configuration to the constructor of an integration, change the `true` to an array like so:

--- a/config/rapidez/sentry-vue.php
+++ b/config/rapidez/sentry-vue.php
@@ -10,7 +10,6 @@ return [
         'sampleRate' => env('SENTRY_VUE_SAMPLE_RATE', 100) / 100,
     ],
 
-
     // For integrations, see: https://docs.sentry.io/platforms/javascript/guides/vue/configuration/integrations/
     // If you want to add extra configuration to the constructor of an integration, change the `true` to an array like so:
     //  'replay' => [

--- a/resources/js/sentry.js
+++ b/resources/js/sentry.js
@@ -48,3 +48,10 @@ document.addEventListener('turbo:load', async () => {
     window.app.$on(['logged-in', 'logout'], () => setUser(window.app.user))
     setUser(window.app.user)
 })
+
+// Allow test errors to be sent from the browser console with `document.dispatchEvent(new Event('sentry-test-error'))`
+if(window.config.sentry.configuration.allow_test_errors) {
+    document.addEventListener('sentry-test-error', () => {
+        throw new Error('Sentry test error')
+    })
+}


### PR DESCRIPTION
This is useful when trying to make sure the frontend error reporting is actually working. Say goodbye to eternally questioning whether I wrote perfect code that never throws an error or if the error reporting is just broken!