### PR TITLE
Add browser deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,19 @@ You may end up having a lot of errors caused by people using really old browsers
 
 Before initializing Sentry, this package will first check whether any of the given variables/functions are nullish (null or undefined). These are checked with `window` as the base variable.
 
+## Filtering errors
+
+You can use the standard Sentry configuration for `ignoreErrors` as described in the [sentry documentation](https://docs.sentry.io/platforms/javascript/guides/vue/configuration/filtering/#using-ignore-errors).
+
+This can be done in the configuration file like so:
+
+```php
+'ignoreErrors' => [
+    'AbortError',
+    '_isDestroyed',
+],
+```
+
 ## License
 
 GNU General Public License v3. Please see [License File](LICENSE) for more information.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ This functionality can be disabled in your `.env`:
 SENTRY_VUE_ALLOW_TEST_ERRORS=false
 ```
 
+## Deprecating older browsers
+
+You may end up having a lot of errors caused by people using really old browsers that don't support some more modern widely supported functions. To combat this, you can use the `deprecations` section in the configuration file:
+
+```php
+'deprecations' => [
+    'String.prototype.replaceAll',
+    'Array.prototype.at',
+]
+```
+
+Before initializing Sentry, this package will first check whether any of the given variables/functions are nullish (null or undefined). These are checked with `window` as the base variable.
+
 ## License
 
 GNU General Public License v3. Please see [License File](LICENSE) for more information.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You may end up having a lot of errors caused by people using really old browsers
 ```
 
 Before initializing Sentry, this package will first check whether any of the given variables/functions are nullish (null or undefined). These are checked with `window` as the base variable.  
-If *any* of them end up being undefined, Sentry will not be loaded and frontend errors will not be logged.
+If *any* of them end up being nullish, Sentry will not be loaded and frontend errors will not be logged.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ You may end up having a lot of errors caused by people using really old browsers
 ]
 ```
 
-Before initializing Sentry, this package will first check whether any of the given variables/functions are nullish (null or undefined). These are checked with `window` as the base variable.
+Before initializing Sentry, this package will first check whether any of the given variables/functions are nullish (null or undefined). These are checked with `window` as the base variable.  
+If *any* of them end up being undefined, Sentry will not be loaded and frontend errors will not be logged.
 
 ## License
 

--- a/config/rapidez/sentry-vue.php
+++ b/config/rapidez/sentry-vue.php
@@ -9,12 +9,17 @@ return [
         // Amount of errors to be logged to sentry (1.00 = 100%)
         'sampleRate' => env('SENTRY_VUE_SAMPLE_RATE', 100) / 100,
 
+        // See the Sentry documentation: https://docs.sentry.io/platforms/javascript/guides/vue/configuration/filtering/#using-ignore-errors
+        'ignoreErrors' => [
+            // 'AbortError',
+        ],
+
         // If any of the following variables/functions are nullish (null or undefined), do not enable Sentry.
         // This helps avoid errors that are only caused by extremely old browsers.
         'deprecations' => [
             // replaceAll has been implemented on all browsers since late 2020. Uncomment to use.
             // 'String.prototype.replaceAll',
-        ]
+        ],
     ],
 
     // For integrations, see: https://docs.sentry.io/platforms/javascript/guides/vue/configuration/integrations/

--- a/config/rapidez/sentry-vue.php
+++ b/config/rapidez/sentry-vue.php
@@ -8,6 +8,13 @@ return [
 
         // Amount of errors to be logged to sentry (1.00 = 100%)
         'sampleRate' => env('SENTRY_VUE_SAMPLE_RATE', 100) / 100,
+
+        // If any of the following variables/functions are nullish (null or undefined), do not enable Sentry.
+        // This helps avoid errors that are only caused by extremely old browsers.
+        'deprecations' => [
+            // replaceAll has been implemented on all browsers since late 2020. Uncomment to use.
+            // 'String.prototype.replaceAll',
+        ]
     ],
 
     // For integrations, see: https://docs.sentry.io/platforms/javascript/guides/vue/configuration/integrations/

--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -1,3 +1,16 @@
 if (import.meta.env.VITE_SENTRY_DSN !== undefined && window.config.sentry.enabled) {
-    (() => import('./sentry.js'))()
+    let deprecations = window.config.sentry.configuration.deprecations || []
+    let deprecated = false
+    deprecations.forEach((deprecation) => {
+        let test = deprecation.split('.').reduce((value, next) => value?.[next] ?? null, window)
+        if (test === null) {
+            deprecated = true
+        }
+    })
+
+    if (deprecated) {
+        console.error('This browser is not supported. Please upgrade to a newer version.')
+    } else {
+        (() => import('./sentry.js'))()
+    }
 }


### PR DESCRIPTION
Sometimes you end up getting spammed with errors in your sentry logs because people are browsing your website with a browser from the stone age. These errors are often unnecessary and end up clogging the queue.

With this, we can check for certain functionalities existing before loading sentry. Errors from browsers that don't support these functions will not get logged.

I have not enabled it by default, but it may be useful to do so?