### PR TITLE
Add filter for scripts that give an error outside the current host

### DIFF
--- a/config/rapidez/sentry-vue.php
+++ b/config/rapidez/sentry-vue.php
@@ -22,6 +22,12 @@ return [
         ],
     ],
 
+    'filters' => [
+        // This filters out any errors that come from scripts not hosted from the current host.
+        // For example, you don't want to see any errors coming from user extensions.
+        'filterExternalUrls' => true
+    ],
+
     // For integrations, see: https://docs.sentry.io/platforms/javascript/guides/vue/configuration/integrations/
     // If you want to add extra configuration to the constructor of an integration, change the `true` to an array like so:
     //  'replay' => [

--- a/resources/js/filters.js
+++ b/resources/js/filters.js
@@ -1,0 +1,15 @@
+import { addBeforeSendMethodHandler } from "./stores/useBeforeSendHandlers"
+
+if (window.config.sentry.filters.filterExternalUrls) {
+    addBeforeSendMethodHandler((event) => {
+        event.exception.values = event.exception.values.filter((error) => {
+            return (new URL(error.stacktrace.frames[0].filename)).hostname == window.location.hostname
+        })
+
+        if (event.exception.values.length == 0) {
+            return null
+        }
+
+        return event
+    })
+}

--- a/resources/js/sentry.js
+++ b/resources/js/sentry.js
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/vue'
 import { runBeforeSendMethodHandlers } from './stores/useBeforeSendHandlers'
+import './filters.js'
 
 // Collect all configured integrations
 let integrations = Object.entries(window.config.sentry.integrations).map(([integration, value]) => {
@@ -22,9 +23,7 @@ let configuration = Object.assign(
         dsn: import.meta.env.VITE_SENTRY_DSN,
         environment: import.meta.env.MODE,
         integrations: integrations,
-        beforeSend(event) {
-            return runBeforeSendMethodHandlers(event)
-        }
+        beforeSend: runBeforeSendMethodHandlers,
     },
     window.config.sentry.configuration
 )

--- a/resources/js/stores/useBeforeSendHandlers.js
+++ b/resources/js/stores/useBeforeSendHandlers.js
@@ -5,5 +5,5 @@ export function addBeforeSendMethodHandler(handler) {
 }
 
 export function runBeforeSendMethodHandlers(event) {
-    return beforeSendMethodHandlers.reduce((event, handler) => handler(event), event)
+    return beforeSendMethodHandlers.reduce((event, handler) => event === null ? null : handler(event), event)
 }

--- a/src/Http/ViewComposers/ConfigComposer.php
+++ b/src/Http/ViewComposers/ConfigComposer.php
@@ -11,6 +11,7 @@ class ConfigComposer
     {
         Config::set('frontend.sentry.configuration', config('rapidez.sentry-vue.configuration'));
         Config::set('frontend.sentry.enabled', config('rapidez.sentry-vue.configuration.enabled'));
+        Config::set('frontend.sentry.filters', config('rapidez.sentry-vue.filters'));
         Config::set('frontend.sentry.integrations', config('rapidez.sentry-vue.integrations'));
     }
 }


### PR DESCRIPTION
Sentry logs any error on the clientside right now, including errors that come from user extensions and external scripts. We don't really care to see these.

To solve this, we can check the source of the top trace from the error's stack trace, and see if it comes from the same hostname as the current `window.location.hostname`.

I figured you'd also want this filter to be disable-able if you want to, so I've added a configuration section for this filter and any future standard filters we might end up dreaming up. Stuff like filtering out sensitive data could be a use case for that.