### PR TITLE
Add fallback for nonexistent stack trace

### DIFF
--- a/resources/js/filters.js
+++ b/resources/js/filters.js
@@ -3,6 +3,10 @@ import { addBeforeSendMethodHandler } from "./stores/useBeforeSendHandlers"
 if (window.config.sentry.filters.filterExternalUrls) {
     addBeforeSendMethodHandler((event) => {
         event.exception.values = event.exception.values.filter((error) => {
+            // Return true if we can't seem to check the stack trace
+            if (!error?.stacktrace?.frames?.[0]?.filename) {
+                return true
+            }
             return (new URL(error.stacktrace.frames[0].filename)).hostname == window.location.hostname
         })
 


### PR DESCRIPTION
I don't know exactly when this happens, but we have a large set of Sentry errors that are caused by this.