### PR TITLE
[5.x] Catch invalid url filenames

### DIFF
--- a/resources/js/filters.js
+++ b/resources/js/filters.js
@@ -7,7 +7,13 @@ if (window.config.sentry.filters.filterExternalUrls) {
             if (!error?.stacktrace?.frames?.[0]?.filename) {
                 return true
             }
-            return (new URL(error.stacktrace.frames[0].filename)).hostname == window.location.hostname
+
+            try {
+                return (new URL(error.stacktrace.frames[0].filename)).hostname == window.location.hostname
+            } catch (e) {
+                // Return true for invalid filenames (e.g. '<anonymous>')
+                return true;
+            }
         })
 
         if (event.exception.values.length == 0) {


### PR DESCRIPTION
Errors that have invalid filenames (e.g. `<anonymous>` triggered by `document.dispatchEvent(new Event('sentry-test-error'))`) would prevent specific errors from being logged.

Now the default to these invalid urls is to capture them just in case.