### PR TITLE
[5.x] Improved tree shaking

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ document.dispatchEvent(new Event('sentry-test-error'))
 This functionality can be disabled in your `.env`:
 
 ```
-SENTRY_VUE_ALLOW_TEST_ERRORS=false
+VITE_SENTRY_VUE_ALLOW_TEST_ERRORS=false
 ```
 
 ## Deprecating older browsers

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^8.1",
-        "rapidez/core": "^4.0",
+        "rapidez/core": "^5.0",
         "sentry/sentry-laravel": "^4.7"
     },
     "autoload": {

--- a/config/rapidez/sentry-vue.php
+++ b/config/rapidez/sentry-vue.php
@@ -4,7 +4,6 @@ return [
     // Configuration as defined in the docs: https://docs.sentry.io/platforms/javascript/guides/vue/configuration/
     'configuration' => [
         'enabled' => env('SENTRY_VUE_ENABLED', true),
-        'allow_test_errors' => env('SENTRY_VUE_ALLOW_TEST_ERRORS', true),
 
         // Amount of errors to be logged to sentry (1.00 = 100%)
         'sampleRate' => env('SENTRY_VUE_SAMPLE_RATE', 100) / 100,
@@ -47,19 +46,17 @@ return [
     //      'blockAllMedia' => true,
     //  ],
     'integrations' => [
-        'browserProfiling' => env('SENTRY_VUE_INTEGRATION_BROWSER_PROFILING', false),
-        'browserTracing' => env('SENTRY_VUE_INTEGRATION_BROWSER_TRACING', false),
-        'captureConsole' => env('SENTRY_VUE_INTEGRATION_CAPTURE_CONSOLE', false),
-        'contextLines' => env('SENTRY_VUE_INTEGRATION_CONTEXT_LINES', false),
-        'debug' => env('SENTRY_VUE_INTEGRATION_DEBUG', false),
-        'extraErrorData' => env('SENTRY_VUE_INTEGRATION_EXTRA_ERROR_DATA', false),
-        'httpClient' => env('SENTRY_VUE_INTEGRATION_HTTP_CLIENT', false),
-        'graphqlClient' => env('SENTRY_VUE_INTEGRATION_GRAPHQL_CLIENT', false),
-        'moduleMetadata' => env('SENTRY_VUE_INTEGRATION_MODULE_METADATA', false),
-        'rewriteFrames' => env('SENTRY_VUE_INTEGRATION_REWRITE_FRAMES', false),
-        'replay' => env('SENTRY_VUE_INTEGRATION_REPLAY', false),
-        'replayCanvas' => env('SENTRY_VUE_INTEGRATION_REPLAY_CANVAS', false),
-        'reportingObserver' => env('SENTRY_VUE_INTEGRATION_REPORTING_OBSERVER', false),
-        'sessionTiming' => env('SENTRY_VUE_INTEGRATION_SESSION_TIMING', false),
+        'browserProfiling' => env('VITE_SENTRY_VUE_INTEGRATION_BROWSER_PROFILING', false),
+        'browserTracing' => env('VITE_SENTRY_VUE_INTEGRATION_BROWSER_TRACING', false),
+        'captureConsole' => env('VITE_SENTRY_VUE_INTEGRATION_CAPTURE_CONSOLE', false),
+        'contextLines' => env('VITE_SENTRY_VUE_INTEGRATION_CONTEXT_LINES', false),
+        'extraErrorData' => env('VITE_SENTRY_VUE_INTEGRATION_EXTRA_ERROR_DATA', false),
+        'graphqlClient' => env('VITE_SENTRY_VUE_INTEGRATION_GRAPHQL_CLIENT', false),
+        'httpClient' => env('VITE_SENTRY_VUE_INTEGRATION_HTTP_CLIENT', false),
+        'moduleMetadata' => env('VITE_SENTRY_VUE_INTEGRATION_MODULE_METADATA', false),
+        'replayCanvas' => env('VITE_SENTRY_VUE_INTEGRATION_REPLAY_CANVAS', false),
+        'replay' => env('VITE_SENTRY_VUE_INTEGRATION_REPLAY', false),
+        'reportingObserver' => env('VITE_SENTRY_VUE_INTEGRATION_REPORTING_OBSERVER', false),
+        'rewriteFrames' => env('VITE_SENTRY_VUE_INTEGRATION_REWRITE_FRAMES', false),
     ],
 ];

--- a/resources/js/sentry.js
+++ b/resources/js/sentry.js
@@ -47,21 +47,22 @@ let init = (app) => {
 
 let collectIntegrations = (integrationsConfig) => {
     // Collect all configured integrations
-    let integrations = []
-
-    // These ifs make tree shaking possible, they will get compiled away.
-    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_BROWSER_PROFILING === 'true' ? integrations.push(browserProfilingIntegration()) : null
-    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_BROWSER_TRACING === 'true' ? integrations.push(browserTracingIntegration(integrationsConfig.browserTracing === true ? undefined : integrationsConfig.browserTracing)) : null
-    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_CAPTURE_CONSOLE === 'true' ? integrations.push(captureConsoleIntegration(integrationsConfig.captureConsole === true ? undefined : integrationsConfig.captureConsole)) : null
-    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_CONTEXT_LINES === 'true' ? integrations.push(contextLinesIntegration(integrationsConfig.contextLines === true ? undefined : integrationsConfig.contextLines)) : null
-    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_EXTRA_ERROR_DATA === 'true' ? integrations.push(extraErrorDataIntegration(integrationsConfig.extraErrorData === true ? undefined : integrationsConfig.extraErrorData)) : null
-    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_GRAPHQL_CLIENT === 'true' ? integrations.push(graphqlClientIntegration(integrationsConfig.graphqlClient === true ? undefined : integrationsConfig.graphqlClient)) : null
-    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_HTTP_CLIENT === 'true' ? integrations.push(httpClientIntegration(integrationsConfig.httpClient === true ? undefined : integrationsConfig.httpClient)) : null
-    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_MODULE_METADATA === 'true' ? integrations.push(moduleMetadataIntegration()) : null
-    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_REPLAY_CANVAS === 'true' ? integrations.push(replayCanvasIntegration()) : null
-    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_REPLAY === 'true' ? integrations.push(replayIntegration()) : null
-    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_REPORTING_OBSERVER === 'true' ? integrations.push(reportingObserverIntegration(integrationsConfig.reportingObserver === true ? undefined : integrationsConfig.reportingObserver)) : null
-    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_REWRITE_FRAMES === 'true' ? integrations.push(rewriteFramesIntegration(integrationsConfig.rewriteFrames === true ? undefined : integrationsConfig.rewriteFrames)) : null
+    let integrations = Object.entries({
+        browserProfiling: import.meta.env.VITE_SENTRY_VUE_INTEGRATION_BROWSER_PROFILING === 'true' ? browserProfilingIntegration : null,
+        browserTracing: import.meta.env.VITE_SENTRY_VUE_INTEGRATION_BROWSER_TRACING === 'true' ? browserTracingIntegration : null,
+        captureConsole: import.meta.env.VITE_SENTRY_VUE_INTEGRATION_CAPTURE_CONSOLE === 'true' ? captureConsoleIntegration : null,
+        cotextLines: import.meta.env.VITE_SENTRY_VUE_INTEGRATION_CONTEXT_LINES === 'true' ? cotextLinesIntegration : null,
+        extraErrorData: import.meta.env.VITE_SENTRY_VUE_INTEGRATION_EXTRA_ERROR_DATA === 'true' ? extraErrorDataIntegration : null,
+        graphqlClient: import.meta.env.VITE_SENTRY_VUE_INTEGRATION_GRAPHQL_CLIENT === 'true' ? graphqlClientIntegration : null,
+        httpClient: import.meta.env.VITE_SENTRY_VUE_INTEGRATION_HTTP_CLIENT === 'true' ? httpClientIntegration : null,
+        moduleMetadata: import.meta.env.VITE_SENTRY_VUE_INTEGRATION_MODULE_METADATA === 'true' ? moduleMetadataIntegration : null,
+        replayCanvas: import.meta.env.VITE_SENTRY_VUE_INTEGRATION_REPLAY_CANVAS === 'true' ? replayCanvasIntegration : null,
+        replay: import.meta.env.VITE_SENTRY_VUE_INTEGRATION_REPLAY === 'true' ? replayIntegration : null,
+        reportingObserver: import.meta.env.VITE_SENTRY_VUE_INTEGRATION_REPORTING_OBSERVER === 'true' ? reportingObserverIntegration : null,
+        rewriteFrames: import.meta.env.VITE_SENTRY_VUE_INTEGRATION_REWRITE_FRAMES === 'true' ? rewriteFramesIntegration : null,
+    })
+        .filter(([configName, integration]) => integration && integrationsConfig[configName] !== false)
+        .map(([configName, integration]) => integration(integrationsConfig[configName] === true ? undefined : integrationsConfig[configName]))
 
     return integrations;
 }

--- a/resources/js/sentry.js
+++ b/resources/js/sentry.js
@@ -51,17 +51,17 @@ let collectIntegrations = (integrationsConfig) => {
 
     // These ifs make tree shaking possible, they will get compiled away.
     import.meta.env.VITE_SENTRY_VUE_INTEGRATION_BROWSER_PROFILING === 'true' ? integrations.push(browserProfilingIntegration()) : null
-    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_BROWSER_TRACING === 'true' ? integrations.push(browserTracingIntegration(integrationsConfig.browserTracing === true ? null : integrationsConfig.browserTracing)) : null
-    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_CAPTURE_CONSOLE === 'true' ? integrations.push(captureConsoleIntegration(integrationsConfig.captureConsole === true ? null : integrationsConfig.captureConsole)) : null
-    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_CONTEXT_LINES === 'true' ? integrations.push(contextLinesIntegration(integrationsConfig.contextLines === true ? null : integrationsConfig.contextLines)) : null
-    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_EXTRA_ERROR_DATA === 'true' ? integrations.push(extraErrorDataIntegration(integrationsConfig.extraErrorData === true ? null : integrationsConfig.extraErrorData)) : null
-    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_GRAPHQL_CLIENT === 'true' ? integrations.push(graphqlClientIntegration(integrationsConfig.graphqlClient === true ? null : integrationsConfig.graphqlClient)) : null
-    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_HTTP_CLIENT === 'true' ? integrations.push(httpClientIntegration(integrationsConfig.httpClient === true ? null : integrationsConfig.httpClient)) : null
+    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_BROWSER_TRACING === 'true' ? integrations.push(browserTracingIntegration(integrationsConfig.browserTracing === true ? undefined : integrationsConfig.browserTracing)) : null
+    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_CAPTURE_CONSOLE === 'true' ? integrations.push(captureConsoleIntegration(integrationsConfig.captureConsole === true ? undefined : integrationsConfig.captureConsole)) : null
+    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_CONTEXT_LINES === 'true' ? integrations.push(contextLinesIntegration(integrationsConfig.contextLines === true ? undefined : integrationsConfig.contextLines)) : null
+    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_EXTRA_ERROR_DATA === 'true' ? integrations.push(extraErrorDataIntegration(integrationsConfig.extraErrorData === true ? undefined : integrationsConfig.extraErrorData)) : null
+    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_GRAPHQL_CLIENT === 'true' ? integrations.push(graphqlClientIntegration(integrationsConfig.graphqlClient === true ? undefined : integrationsConfig.graphqlClient)) : null
+    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_HTTP_CLIENT === 'true' ? integrations.push(httpClientIntegration(integrationsConfig.httpClient === true ? undefined : integrationsConfig.httpClient)) : null
     import.meta.env.VITE_SENTRY_VUE_INTEGRATION_MODULE_METADATA === 'true' ? integrations.push(moduleMetadataIntegration()) : null
     import.meta.env.VITE_SENTRY_VUE_INTEGRATION_REPLAY_CANVAS === 'true' ? integrations.push(replayCanvasIntegration()) : null
     import.meta.env.VITE_SENTRY_VUE_INTEGRATION_REPLAY === 'true' ? integrations.push(replayIntegration()) : null
-    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_REPORTING_OBSERVER === 'true' ? integrations.push(reportingObserverIntegration(integrationsConfig.reportingObserver === true ? null : integrationsConfig.reportingObserver)) : null
-    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_REWRITE_FRAMES === 'true' ? integrations.push(rewriteFramesIntegration(integrationsConfig.rewriteFrames === true ? null : integrationsConfig.rewriteFrames)) : null
+    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_REPORTING_OBSERVER === 'true' ? integrations.push(reportingObserverIntegration(integrationsConfig.reportingObserver === true ? undefined : integrationsConfig.reportingObserver)) : null
+    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_REWRITE_FRAMES === 'true' ? integrations.push(rewriteFramesIntegration(integrationsConfig.rewriteFrames === true ? undefined : integrationsConfig.rewriteFrames)) : null
 
     return integrations;
 }

--- a/resources/js/sentry.js
+++ b/resources/js/sentry.js
@@ -1,24 +1,27 @@
-import * as Sentry from '@sentry/vue'
+import {
+    init as initSentry,
+    setUser as sentrySetUser,
+    setTag,
+    browserProfilingIntegration,
+    browserTracingIntegration,
+    captureConsoleIntegration,
+    contextLinesIntegration,
+    extraErrorDataIntegration,
+    httpClientIntegration,
+    graphqlClientIntegration,
+    moduleMetadataIntegration,
+    rewriteFramesIntegration,
+    replayIntegration,
+    replayCanvasIntegration,
+    reportingObserverIntegration
+} from '@sentry/vue'
+
 import { runBeforeSendMethodHandlers } from './stores/useBeforeSendHandlers'
 import './filters.js'
 
 let initialized = false
 let init = (app) => {
     initialized = true;
-    // Collect all configured integrations
-    let integrations = Object.entries(window.config.sentry.integrations).map(([integration, value]) => {
-        if (!value) {
-            return
-        }
-
-        let integrationFunction = Sentry[integration + 'Integration']
-        if(!integrationFunction) {
-            return
-        }
-
-        return value === true ? integrationFunction() : integrationFunction(value)
-    }).filter((value) => value !== undefined)
-
     window.config.sentry.configuration.allowUrls.push(window.config.base_url)
     window.config.sentry.configuration.tracePropagationTargets.push(window.config.base_url)
     window.config.sentry.configuration.tracePropagationTargets.push(window.config.magento_url)
@@ -32,30 +35,51 @@ let init = (app) => {
             app,
             dsn: import.meta.env.VITE_SENTRY_DSN,
             environment: import.meta.env.MODE,
-            integrations: integrations,
+            integrations: collectIntegrations(window.config.sentry.integrations),
             beforeSend: runBeforeSendMethodHandlers,
         },
         window.config.sentry.configuration
     )
 
     // Initialize Sentry
-    Sentry.init(configuration)
+    initSentry(configuration)
+}
+
+let collectIntegrations = (integrationsConfig) => {
+    // Collect all configured integrations
+    let integrations = []
+
+    // These ifs make tree shaking possible, they will get compiled away.
+    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_BROWSER_PROFILING === 'true' ? integrations.push(browserProfilingIntegration()) : null
+    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_BROWSER_TRACING === 'true' ? integrations.push(browserTracingIntegration(integrationsConfig.browserTracing === true ? null : integrationsConfig.browserTracing)) : null
+    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_CAPTURE_CONSOLE === 'true' ? integrations.push(captureConsoleIntegration(integrationsConfig.captureConsole === true ? null : integrationsConfig.captureConsole)) : null
+    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_CONTEXT_LINES === 'true' ? integrations.push(contextLinesIntegration(integrationsConfig.contextLines === true ? null : integrationsConfig.contextLines)) : null
+    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_EXTRA_ERROR_DATA === 'true' ? integrations.push(extraErrorDataIntegration(integrationsConfig.extraErrorData === true ? null : integrationsConfig.extraErrorData)) : null
+    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_GRAPHQL_CLIENT === 'true' ? integrations.push(graphqlClientIntegration(integrationsConfig.graphqlClient === true ? null : integrationsConfig.graphqlClient)) : null
+    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_HTTP_CLIENT === 'true' ? integrations.push(httpClientIntegration(integrationsConfig.httpClient === true ? null : integrationsConfig.httpClient)) : null
+    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_MODULE_METADATA === 'true' ? integrations.push(moduleMetadataIntegration()) : null
+    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_REPLAY_CANVAS === 'true' ? integrations.push(replayCanvasIntegration()) : null
+    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_REPLAY === 'true' ? integrations.push(replayIntegration()) : null
+    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_REPORTING_OBSERVER === 'true' ? integrations.push(reportingObserverIntegration(integrationsConfig.reportingObserver === true ? null : integrationsConfig.reportingObserver)) : null
+    import.meta.env.VITE_SENTRY_VUE_INTEGRATION_REWRITE_FRAMES === 'true' ? integrations.push(rewriteFramesIntegration(integrationsConfig.rewriteFrames === true ? null : integrationsConfig.rewriteFrames)) : null
+
+    return integrations;
 }
 
 // Functionality to link a user to the Sentry messages
 let setUser = (user) => {
     if(user.is_logged_in) {
-        Sentry.setUser({
+        sentrySetUser({
             id: user.id,
             username: [user.firstname, user.lastname].filter(Boolean).join(' '),
             email: user.email,
         })
     } else {
-        Sentry.setUser(null)
+        sentrySetUser(null)
     }
 
     // Add an extra 'logged_in' tag to errors
-    Sentry.setTag('logged_in', user.is_logged_in)
+    setTag('logged_in', user.is_logged_in)
 }
 
 if (window.app) {
@@ -66,12 +90,13 @@ document.addEventListener('vue:loaded', async (event) => {
     if (!initialized) {
         init(event.details.vue);
     }
-    window.$on(['logged-in', 'logged-out'], () => setUser(window.app.config.globalProperties.user.value))
+    window.$on('logged-in', () => setUser(window.app.config.globalProperties.user.value))
+    window.$on('logged-out', () => setUser(window.app.config.globalProperties.user.value))
     setUser(window.app.config.globalProperties.user.value)
 })
 
-// Allow test errors to be sent from the browser console with `document.dispatchEvent(new Event('sentry-test-error'))`
-if(window.config.sentry.configuration.allow_test_errors) {
+if(import.meta.env.VITE_SENTRY_VUE_ALLOW_TEST_ERRORS !== 'false') {
+    // Allow test errors to be sent from the browser console with `document.dispatchEvent(new Event('sentry-test-error'))`
     document.addEventListener('sentry-test-error', () => {
         throw new Error('Sentry test error')
     })

--- a/resources/js/sentry.js
+++ b/resources/js/sentry.js
@@ -51,7 +51,7 @@ let collectIntegrations = (integrationsConfig) => {
         browserProfiling: import.meta.env.VITE_SENTRY_VUE_INTEGRATION_BROWSER_PROFILING === 'true' ? browserProfilingIntegration : null,
         browserTracing: import.meta.env.VITE_SENTRY_VUE_INTEGRATION_BROWSER_TRACING === 'true' ? browserTracingIntegration : null,
         captureConsole: import.meta.env.VITE_SENTRY_VUE_INTEGRATION_CAPTURE_CONSOLE === 'true' ? captureConsoleIntegration : null,
-        cotextLines: import.meta.env.VITE_SENTRY_VUE_INTEGRATION_CONTEXT_LINES === 'true' ? cotextLinesIntegration : null,
+        contextLines: import.meta.env.VITE_SENTRY_VUE_INTEGRATION_CONTEXT_LINES === 'true' ? contextLinesIntegration : null,
         extraErrorData: import.meta.env.VITE_SENTRY_VUE_INTEGRATION_EXTRA_ERROR_DATA === 'true' ? extraErrorDataIntegration : null,
         graphqlClient: import.meta.env.VITE_SENTRY_VUE_INTEGRATION_GRAPHQL_CLIENT === 'true' ? graphqlClientIntegration : null,
         httpClient: import.meta.env.VITE_SENTRY_VUE_INTEGRATION_HTTP_CLIENT === 'true' ? httpClientIntegration : null,


### PR DESCRIPTION
**BREAKING**

This PR will require users to prefix all their `SENTRY_VUE_INTEGRATION_...` configuration with `VITE_` 
As wel as prefix `SENTRY_VUE_ALLOW_TEST_ERRORS` with `VITE_`

---

This PR improves Tree shaking by explicitly importing used Sentry functions and integrations.
Only by utilizing the `import.meta.env` variables (directly or indirectly) Vite will know at compile time which integrations are used and can skip compiling them. The old method of getting it from PHP somewhere prevented this.

Before (with no integrations enabled): 1.18MB (Gzipped 136KB)
<img width="359" height="111" alt="image" src="https://github.com/user-attachments/assets/522e77e2-cc76-4ef7-9584-712a6364751c" />
After (with no integrations enabled): 341KB (gzipped 31KB)
<img width="360" height="78" alt="image" src="https://github.com/user-attachments/assets/aa6539e9-1924-4361-9e25-d7f9ab8c8826" />