### PR TITLE
[4.x] Add Laravel filtering & add the possibility for external filter lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,11 @@ If *any* of them end up being nullish, Sentry will not be loaded and frontend er
 
 ## Filtering errors
 
+### Vue
+
 You can use the standard Sentry configuration for `ignoreErrors` as described in the [sentry documentation](https://docs.sentry.io/platforms/javascript/guides/vue/configuration/filtering/#using-ignore-errors).
 
-This can be done in the configuration file like so:
+This can be done in the `config/rapidez/sentry-vue.php` configuration file like so:
 
 ```php
 'ignoreErrors' => [
@@ -99,6 +101,38 @@ This can be done in the configuration file like so:
     '_isDestroyed',
 ],
 ```
+
+### Laravel
+
+If you want to implement error filtering from Laravel, you will have to enable the `before_send` handler in your `config/sentry.php`:
+
+```php
+'before_send' => [\Rapidez\Sentry\Filters\SentryFilter::class, 'beforeSend'],
+```
+
+You can then configure your `config/rapidez/sentry.php` as follows:
+```php
+// List of errors to ignore
+'ignoreErrors' => [
+    ['message' => 'Unnecessary error'],
+    ['exception' => \App\UnnecessaryError::class],
+],
+```
+
+You can ignore either messages that contain certain strings, or whole Exception classes. 
+
+### Global filtering
+
+You can also use an external JSON file to filter errors globally. This has the same format as the list of ignoreErrors for Laravel (but then in json). For example:
+
+```json
+{
+    {"message": "Unnecessary error"},
+    {"exception": "\\App\\UnnecessaryError"},
+},
+```
+
+The messages will currently be used for both Laravel and Vue filtering.
 
 ## Linking frontend errors to Magento Errors (Distributed Tracing)
 

--- a/config/rapidez/sentry.php
+++ b/config/rapidez/sentry.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    // URL to a file that contains a list of ignored error messages
+    // Note that this file will also be used for extra filters in sentry-vue
+    'filterList' => null,
+
+    // List of errors to ignore
+    'ignoreErrors' => [
+        // ['message' => 'Unnecessary error'],
+        // ['exception' => \App\UnnecessaryError::class],
+    ],
+];

--- a/src/Cache/SentryFilterList.php
+++ b/src/Cache/SentryFilterList.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Rapidez\Sentry\Cache;
+
+use Illuminate\Support\Str;
+
+class SentryFilterList
+{
+    /** @return array<string, string> */
+    public function getCachedFilterList(): array
+    {
+        return cache()
+            ->store('rapidez:multi')
+            ->flexible(
+                'sentry-filter-list',
+                [now()->addHour(), now()->addDay()],
+                $this->getFilterList(...),
+            );
+    }
+
+    /** @return array<string, string> */
+    protected function getFilterList(): array
+    {
+        $path = config('rapidez.sentry.filterList', null);
+
+        if (! $path) {
+            return [];
+        }
+
+        if (!Str::isUrl($path)) {
+            return [];
+        }
+
+        $fileData = file_get_contents($path);
+        if (! $fileData) {
+            return [];
+        }
+
+        $jsonData = json_decode($fileData, true);
+        if (! is_array($jsonData)) {
+            return [];
+        }
+
+        return $jsonData;
+    }
+}

--- a/src/Filters/SentryFilter.php
+++ b/src/Filters/SentryFilter.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rapidez\Sentry\Filters;
+
+use Sentry\Event;
+use Sentry\EventHint;
+
+class SentryFilter
+{
+    public static function beforeSend(Event $event, EventHint $hint): ?Event
+    {
+        $filterList = resolve(\Rapidez\Sentry\Cache\SentryFilterList::class)->getCachedFilterList();
+
+        $messagesToFilter = collect($filterList)->pluck('message')->whereNotNull();
+        $exceptionsToFilter = collect($filterList)->pluck('exception')->whereNotNull();
+
+        if ($messagesToFilter->contains(fn($message) => str_contains($event->getMessage(), $message))) {
+            return null;
+        }
+
+        if ($exceptionsToFilter->contains(fn($exception) => $hint->exception instanceof $exception)) {
+            return null;
+        }
+
+        return $event;
+    }
+}

--- a/src/SentryServiceProvider.php
+++ b/src/SentryServiceProvider.php
@@ -11,14 +11,53 @@ class SentryServiceProvider extends ServiceProvider
     public function register()
     {
         $this->mergeConfigFrom(__DIR__.'/../config/rapidez/sentry-vue.php', 'rapidez.sentry-vue');
+        $this->mergeConfigFrom(__DIR__.'/../config/rapidez/sentry.php', 'rapidez.sentry');
     }
 
     public function boot()
     {
+        $this->bootComposers()
+            ->bootIgnoreLists()
+            ->bootPublishes();
+    }
+
+    protected function bootComposers(): static
+    {
+        View::composer('rapidez::layouts.app', ConfigComposer::class);
+
+        return $this;
+    }
+
+    protected function bootIgnoreLists(): static
+    {
+        $filterList = resolve(\Rapidez\Sentry\Cache\SentryFilterList::class)->getCachedFilterList();
+
+        $vueList = collect($filterList)
+            ->pluck('message')
+            ->merge(config('rapidez.sentry-vue.configuration.ignoreErrors', []))
+            ->whereNotNull()
+            ->unique();
+
+        $laravelList = collect($filterList)
+            ->merge(config('rapidez.sentry.ignoreErrors', []))
+            ->whereNotNull()
+            ->unique();
+
+        config([
+            'rapidez.sentry-vue.configuration.ignoreErrors' => $vueList->values()->all(),
+            'rapidez.sentry.ignoreErrors' => $laravelList->values()->all(),
+        ]);
+
+        return $this;
+    }
+
+    protected function bootPublishes(): static
+    {
         $this->publishes([
             __DIR__.'/../config/rapidez/sentry-vue.php' => config_path('rapidez/sentry-vue.php'),
+            __DIR__.'/../config/rapidez/sentry.php' => config_path('rapidez/sentry.php'),
         ], 'rapidez-sentry-config');
 
-        View::composer('rapidez::layouts.app', ConfigComposer::class);
+        return $this;
     }
 }


### PR DESCRIPTION
ref: J2-478

This PR adds two things:
- Functionality that allows for external URLs to be used to filter
- Actually filtering errors that come from Laravel, as opposed to only the ones that come from the frontend.

