### PR TITLE
Added network event sanitizers so replay fetch bodies can be enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,36 @@ Then in Magento make sure to enable "Tracing", "Performance tracking", and to se
 
 With this set up your Rapidez and Magento Sentry should be linked with each other.
 
+## Record network details
+
+By default Sentry blocks all text, inputs, images and request/response bodies: https://docs.sentry.io/platforms/javascript/session-replay/privacy/#privacy-configuration
+
+If you want to change this behaviour, you can override these in `config/sentry-vue.php`
+```php
+...
+    'integrations' => [
+        ...
+        'replay' => [
+            'maskAllText' => false,
+            'blockAllMedia' => false,
+            'networkDetailAllowUrls' => [
+                'https://example.com',
+                'https://magento.example.com',
+            ],
+        ],
+        ...
+    ],
+    ...
+```
+
+By setting "networkDetailAllowUrls" the request bodies and responses will be reported as well. This means some personal information could be sent over. We have a sanitizer in place to reduce the impact.
+You can extend the values filtered out with the following .env variables
+```env
+SENTRY_SEND_DEFAULT_PII="true"
+VITE_SENTRY_SANITIZE_HEADERS="Cookie Set-Cookie"
+VITE_SENTRY_SANITIZE_JSON_VALUES="password iban"
+```
+
 ## License
 
 GNU General Public License v3. Please see [License File](LICENSE) for more information.

--- a/config/rapidez/sentry-vue.php
+++ b/config/rapidez/sentry-vue.php
@@ -20,6 +20,7 @@ return [
 
         // Only report errors for matching urls, by default the shop url will be used
         'allowUrls' => explode(' ', env('SENTRY_VUE_ALLOW_URLS', '') ),
+        'sendDefaultPii' => (bool) env('SENTRY_SEND_DEFAULT_PII', false),
 
         // See the Sentry documentation: https://docs.sentry.io/platforms/javascript/guides/vue/configuration/filtering/#using-ignore-errors
         'ignoreErrors' => [

--- a/resources/js/sanitization.js
+++ b/resources/js/sanitization.js
@@ -9,10 +9,10 @@ export function sanitizeNetworkEvent(event) {
         if (!headerToSanitize) {
             continue;
         }
-        if (event.data.payload.data.request.headers[headerToSanitize]) {
+        if (event.data.payload.data.request?.headers?.[headerToSanitize]) {
             event.data.payload.data.request.headers[headerToSanitize] = '[Filtered]'
         }
-        if (event.data.payload.data.response.headers[headerToSanitize]) {
+        if (event.data.payload.data.response?.headers?.[headerToSanitize]) {
             event.data.payload.data.response.headers[headerToSanitize] = '[Filtered]'
         }
     }
@@ -49,7 +49,6 @@ export function sanitizeNetworkEvent(event) {
                 continue;
             }
             const re = new RegExp(`("?${jsonValueToSanitize}"?: ?")([^"]+)(")`, 'g')
-            requestAndResponse.request.body = requestAndResponse.request.body?.replaceAll(re, '$1[Filtered]$3')
             body = body?.replaceAll(re, '$1[Filtered]$3')
         }
 
@@ -60,8 +59,12 @@ export function sanitizeNetworkEvent(event) {
         return body
     }
 
-    event.data.payload.data.request.body = performSanitization(event.data.payload.data.request.body)
-    event.data.payload.data.response.body = performSanitization(event.data.payload.data.response.body)
+    if (event?.data?.payload?.data?.request?.body) {
+        event.data.payload.data.request.body = performSanitization(event.data.payload.data.request.body)
+    }
+    if (event?.data?.payload?.data?.response?.body) {
+        event.data.payload.data.response.body = performSanitization(event.data.payload.data.response.body)
+    }
 
     return event;
 }

--- a/resources/js/sanitization.js
+++ b/resources/js/sanitization.js
@@ -1,0 +1,67 @@
+export function sanitizeNetworkEvent(event) {
+    for (const headerToSanitize of [
+        'Authorization',
+        'X-CSRF-Token',
+        'Cookie',
+        'Set-Cookie',
+        ...(import.meta.env.VITE_SENTRY_SANITIZE_HEADERS || '').split(/ |,/),
+    ]) {
+        if (!headerToSanitize) {
+            continue;
+        }
+        if (event.data.payload.data.request.headers[headerToSanitize]) {
+            event.data.payload.data.request.headers[headerToSanitize] = '[Filtered]'
+        }
+        if (event.data.payload.data.response.headers[headerToSanitize]) {
+            event.data.payload.data.response.headers[headerToSanitize] = '[Filtered]'
+        }
+    }
+
+    let performSanitization = (body) => {
+        const originalType = typeof body;
+        if (originalType === 'object') {
+            try {
+                body = JSON.stringify(body)
+            } catch (e) {
+                // Rather safe than sorry, if it fails we empty the response body
+                body = '{}'
+            }
+        }
+
+        for (const jsonValueToSanitize of [
+            'password',
+            'token',
+            'mask',
+            'cart_id',
+            'postcode',
+            'city',
+            'customer_telephone',
+            'telephone',
+            'fax',
+            'vat_id',
+            'po_number',
+            'pay_return_url',
+            'pay_redirect_url',
+            'iban',
+            ...(import.meta.env.VITE_SENTRY_SANITIZE_JSON_VALUES || '').split(/ |,/),
+        ]) {
+            if (!jsonValueToSanitize) {
+                continue;
+            }
+            const re = new RegExp(`("?${jsonValueToSanitize}"?: ?")([^"]+)(")`, 'g')
+            requestAndResponse.request.body = requestAndResponse.request.body?.replaceAll(re, '$1[Filtered]$3')
+            body = body?.replaceAll(re, '$1[Filtered]$3')
+        }
+
+        if (originalType === 'object') {
+            return JSON.parse(body)
+        }
+
+        return body
+    }
+
+    event.data.payload.data.request.body = performSanitization(event.data.payload.data.request.body)
+    event.data.payload.data.response.body = performSanitization(event.data.payload.data.response.body)
+
+    return event;
+}

--- a/resources/js/sentry.js
+++ b/resources/js/sentry.js
@@ -18,6 +18,7 @@ import {
 
 import { runBeforeSendMethodHandlers } from './stores/useBeforeSendHandlers'
 import './filters.js'
+import { sanitizeNetworkEvent } from './sanitization.js'
 
 let initialized = false
 let init = (app) => {
@@ -46,6 +47,19 @@ let init = (app) => {
 }
 
 let collectIntegrations = (integrationsConfig) => {
+    integrationsConfig.replay = {
+        beforeAddRecordingEvent: (event) => {
+            if (
+                event?.data?.payload?.data?.request?.body &&
+                event?.data?.payload?.data?.response?.body
+            ) {
+                return sanitizeNetworkEvent(event);
+            }
+
+            return event;
+        },
+        ...(integrationsConfig.replay || {}),
+    }
     // Collect all configured integrations
     let integrations = Object.entries({
         browserProfiling: import.meta.env.VITE_SENTRY_VUE_INTEGRATION_BROWSER_PROFILING === 'true' ? browserProfilingIntegration : null,
@@ -93,6 +107,7 @@ document.addEventListener('vue:loaded', async (event) => {
     }
     window.$on('logged-in', () => setUser(window.app.config.globalProperties.user.value))
     window.$on('logged-out', () => setUser(window.app.config.globalProperties.user.value))
+    window.$on('checkout-success', (order) => setTag('order_increment_id', order?.number))
     setUser(window.app.config.globalProperties.user.value)
 })
 


### PR DESCRIPTION
The filtering list have been taken from OpenReplay, and it will only be uses when `networkDetailAllowUrls` has been filled.
By default it will never record the bodies of urls not in this whitelist.